### PR TITLE
[Feat] 레이아웃 적용, 라우터 수정

### DIFF
--- a/src/components/MypageForm/index.tsx
+++ b/src/components/MypageForm/index.tsx
@@ -1,0 +1,19 @@
+import * as S from './style'
+
+function index() {
+  return (
+    <>
+      <S.myInfoDiv>
+        My Info
+      </S.myInfoDiv>
+      <div>
+        과거 연차 내역
+      </div>
+      <div>
+        과거 당직 내역
+      </div>
+    </>
+  )
+}
+
+export default index

--- a/src/components/MypageForm/style.ts
+++ b/src/components/MypageForm/style.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import theme from "../../styles/theme";
+
+export const myInfoDiv = styled.div`
+  width: 100%;
+  background-color: ${theme.color.beige};
+  color: ${theme.color.lightBrown}
+`

--- a/src/components/common/Layout/Header/index.tsx
+++ b/src/components/common/Layout/Header/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function Header() {
   return (
-    <div>Header</div>
+    <header>Header</header>
   )
 }
 

--- a/src/components/common/Layout/Nav/index.tsx
+++ b/src/components/common/Layout/Nav/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function Nav() {
   return (
-    <div>Nav</div>
+    <nav>Nav</nav>
   )
 }
 

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -2,14 +2,15 @@ import React from 'react'
 import Header from './Header'
 import Nav from './Nav'
 import { Outlet } from 'react-router-dom'
+import * as S from './styles'
 
 function Layout() {
   return (
-    <div>
+    <S.gridDiv>
       <Header/>
       <Nav/>
       <Outlet/>
-    </div>
+    </S.gridDiv>
   )
 }
 

--- a/src/components/common/Layout/styles.ts
+++ b/src/components/common/Layout/styles.ts
@@ -1,0 +1,29 @@
+import theme from "../../../styles/theme";
+import styled from "styled-components";
+
+export const gridDiv = styled.div`
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  grid-template-rows: 3rem 1fr;
+  header {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+    align-self: center;
+    justify-self: end;
+  }
+  nav {
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
+    align-self: center;
+    justify-self: center;
+  }
+  .content {
+    align-self: center;
+    justify-self: center;
+
+    display: flex;
+    flex-wrap: wrap;
+
+    padding: 1rem;
+  }
+`

--- a/src/pages/AdminApprovalPage/AdminApprovalPage.tsx
+++ b/src/pages/AdminApprovalPage/AdminApprovalPage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function AdminApprovalPage() {
   return (
-    <div>AdminApprovalPage</div>
+    <div className='content'>AdminApprovalPage</div>
   )
 }
 

--- a/src/pages/AdminAuthPage/AdminAuthPage.tsx
+++ b/src/pages/AdminAuthPage/AdminAuthPage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function AdminAuthPage() {
   return (
-    <div>AdminAuthPage</div>
+    <div className='content'>AdminAuthPage</div>
   )
 }
 

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function MainPage() {
   return (
-    <div>MainPage</div>
+    <div className='content'>MainPage</div>
   )
 }
 

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import MypageForm from '../../components/MypageForm'
 
 function Mypage() {
   return (
-    <div>Mypage</div>
+    <div className='content'>
+      <MypageForm />
+    </div>
   )
 }
 

--- a/src/routes/routers.tsx
+++ b/src/routes/routers.tsx
@@ -12,15 +12,15 @@ import ErrorPage from '../pages/ErrorPage/ErrorPage';
 function Routers() {
   return (
     <Routes>
+      <Route index element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
       <Route path="/" element={<Layout />}>
-        <Route index element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
         <Route path="/main" element={<MainPage/>}/>
         <Route path="/mypage" element={<Mypage/>} />
         <Route path="/adminApproval" element={<AdminApprovalPage/>} />
         <Route path="/adminAuth" element={<AdminAuthPage/>} />
-        <Route path="*" element={<ErrorPage/>}/>
       </Route>
+      <Route path="*" element={<ErrorPage/>}/>
     </Routes>
   );
 }


### PR DESCRIPTION
# 레이아웃 적용, 라우터 수정

### 변경 사항
- 🚀  레이아웃을 적용했습니다.
- 🔧  라우터에서 로그인, 회원가입, 404페이지에서는 레이아웃이 기본 적용되지 않도록 수정했습니다.

### 스크린샷 (해당하는 경우):
![image](https://user-images.githubusercontent.com/120410962/235898259-af67bd8a-9eac-4088-a22a-dee1e5c0e3e6.png)
- 영역을 세 군데(`header`, `nav`, `content`)로 구분했습니다.
- `content`영역이 각 페이지의 내용이 들어가는 곳입니다.
- 이를 위해 각 페이지 컴포넌트의 최상위 `div` 태그마다 `className='content'` 추가해 놓았습니다.
- `flex-wrap`을 이용해 자동 줄 바꿈 되도록 했습니다.
- (`My Info`를 `widht: 100%`로 설정 -> 나머지 두 항목(`과거 연차 내역`, `과거 당직 내역`)이 밑으로 줄 바꿈 된 모습)
- 가로, 세로 모두 가운데 정렬하였고, 내부 여백은 `1rem`으로 설정 하였습니다.
- gap(내부 항목 간 여백)의 경우 필요하다고 하시면 다시 설정해서 pr보낼게요.<br>
![image](https://user-images.githubusercontent.com/120410962/235899632-a58587fa-de51-46ac-883d-a15384ed1c51.png)
- `Form`폴더 안에 컴포넌트들 연결할 때 이렇게 빈 태그로 연결해야 자동 줄 바꿈이 적용됩니다. 이 부분은 자동 줄바꿈이 필요하지 않을 경우 상관하지 않으셔도 됩니다.